### PR TITLE
Add support for running repeated test cases concurrently

### DIFF
--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -96,20 +96,20 @@ func RunSuite(s *test.Suite, context Context) ([]*Result, error) {
 				}()
 
 				r, f, err := RunTest(e, c)
-				if err != nil {
-					lock.Lock()
-					errs = append(errs, err)
-					lock.Unlock()
-					return
-				}
 
 				lock.Lock()
-				if r != nil {
-					results = append(results, r)
+
+				if err != nil {
+					errs = append(errs, err)
+				} else {
+					if r != nil {
+						results = append(results, r)
+					}
+					if f != nil {
+						futures = append(futures, f)
+					}
 				}
-				if f != nil {
-					futures = append(futures, f)
-				}
+
 				lock.Unlock()
 			}()
 		}

--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -80,6 +80,13 @@ func RunSuite(s *test.Suite, context Context) ([]*Result, error) {
 		var errs []error
 
 		for i := 0; i < n; i++ {
+			lock.Lock()
+			nerr := len(errs)
+			lock.Unlock()
+			if nerr > 0 {
+				break
+			}
+
 			wg.Add(1)
 			sem <- struct{}{}
 			go func() {
@@ -108,6 +115,10 @@ func RunSuite(s *test.Suite, context Context) ([]*Result, error) {
 		}
 
 		wg.Wait()
+
+		if len(errs) > 0 {
+			return nil, errs[0]
+		}
 	}
 
 	for _, e := range context.Gendoc {

--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -94,11 +94,8 @@ func RunSuite(s *test.Suite, context Context) ([]*Result, error) {
 					<-sem
 					wg.Done()
 				}()
-
 				r, f, err := RunTest(e, c)
-
 				lock.Lock()
-
 				if err != nil {
 					errs = append(errs, err)
 				} else {
@@ -109,7 +106,6 @@ func RunSuite(s *test.Suite, context Context) ([]*Result, error) {
 						futures = append(futures, f)
 					}
 				}
-
 				lock.Unlock()
 			}()
 		}

--- a/src/hunit/test/test.go
+++ b/src/hunit/test/test.go
@@ -67,17 +67,18 @@ type MessageExchange struct {
 
 // A test case
 type Case struct {
-	Id       string            `yaml:"id"`
-	Wait     time.Duration     `yaml:"wait"`
-	Repeat   int               `yaml:"repeat"`
-	Gendoc   bool              `yaml:"gendoc"`
-	Title    string            `yaml:"title"`
-	Comments string            `yaml:"doc"`
-	Params   map[string]string `yaml:"params"`
-	Request  Request           `yaml:"request"`
-	Response Response          `yaml:"response"`
-	Stream   *Stream           `yaml:"websocket"`
-	Vars     yaml.MapSlice     `yaml:"vars"`
+	Id         string            `yaml:"id"`
+	Wait       time.Duration     `yaml:"wait"`
+	Repeat     int               `yaml:"repeat"`
+	Concurrent int               `yaml:"concurrent"`
+	Gendoc     bool              `yaml:"gendoc"`
+	Title      string            `yaml:"title"`
+	Comments   string            `yaml:"doc"`
+	Params     map[string]string `yaml:"params"`
+	Request    Request           `yaml:"request"`
+	Response   Response          `yaml:"response"`
+	Stream     *Stream           `yaml:"websocket"`
+	Vars       yaml.MapSlice     `yaml:"vars"`
 }
 
 // Determine if this case is documented or not


### PR DESCRIPTION
A test case which uses the `repeat` option to execute the request multiple times can now run the repeated requests concurrently by setting the `concurrent` option to the maximum number of requests that may be executed in parallel.

if undefined or if set to a value less than 1, the `concurrent` option defaults to 1, which causes requests to be executed serially.

For example, to fetch a resource 10 times with a maximum of 5 requests running concurrently at any given point, you might use the following:

```yaml
 -
  repeat: 10
  concurrent: 5

  request:
    method: GET
    url: https://www.google.com/

  response:
    status: 200
```