### PR TITLE
Adding support for required tests

### DIFF
--- a/example/deps.yml
+++ b/example/deps.yml
@@ -1,5 +1,16 @@
 
 -
+  # This test can fail because it is not required
+  request:
+    method: GET
+    url: https://raw.githubusercontent.com/instaunit/instaunit/NOT_FOUND
+  
+  response:
+    status: 200
+
+
+-
+  # This test must not fail or subsequent tests will be skipped
   require: true
    
   request:
@@ -11,7 +22,6 @@
 
 -
   # This test will fail implicitly due to dependency failure
-  
   request:
     method: GET
     url: https://raw.githubusercontent.com/instaunit/instaunit/master/example/entity.json

--- a/example/deps.yml
+++ b/example/deps.yml
@@ -1,0 +1,20 @@
+
+-
+  require: true
+   
+  request:
+    method: GET
+    url: https://raw.githubusercontent.com/instaunit/instaunit/NOT_FOUND
+  
+  response:
+    status: 200
+
+-
+  # This test will fail implicitly due to dependency failure
+  
+  request:
+    method: GET
+    url: https://raw.githubusercontent.com/instaunit/instaunit/master/example/entity.json
+  
+  response:
+    status: 200

--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -63,7 +63,13 @@ func RunSuite(s *test.Suite, context Context) ([]*Result, error) {
 		}
 	}
 
+	precond := true
 	for _, e := range s.Cases {
+		if !precond {
+			results = append(results, &Result{Name: fmt.Sprintf("%v %v (dependency failed)\n", e.Request.Method, e.Request.URL), Skipped: true})
+			continue
+		}
+
 		n := e.Repeat
 		if n < 1 {
 			n = 1
@@ -97,8 +103,14 @@ func RunSuite(s *test.Suite, context Context) ([]*Result, error) {
 				r, f, err := RunTest(e, c)
 				lock.Lock()
 				if err != nil {
+					if e.Require {
+						precond = false
+					}
 					errs = append(errs, err)
 				} else {
+					if e.Require {
+						precond = precond && r.Success
+					}
 					if r != nil {
 						results = append(results, r)
 					}

--- a/src/hunit/result.go
+++ b/src/hunit/result.go
@@ -8,6 +8,7 @@ import (
 type Result struct {
 	Name             string
 	Success          bool
+	Skipped          bool
 	Errors           []error
 	Reqdata, Rspdata []byte
 	Runtime          time.Duration

--- a/src/hunit/test/test.go
+++ b/src/hunit/test/test.go
@@ -74,6 +74,7 @@ type Case struct {
 	Gendoc     bool              `yaml:"gendoc"`
 	Title      string            `yaml:"title"`
 	Comments   string            `yaml:"doc"`
+	Require    bool              `yaml:"require"`
 	Params     map[string]string `yaml:"params"`
 	Request    Request           `yaml:"request"`
 	Response   Response          `yaml:"response"`

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -49,7 +49,7 @@ func main() {
 
 // You know what it does
 func app() int {
-	var tests, failures, errors int
+	var tests, skipped, failures, errors int
 	var headerSpecs, serviceSpecs flagList
 
 	cmdline := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -367,15 +367,20 @@ suites:
 
 		var count int
 		for _, r := range results {
-			if r.Success {
-				color.New(color.FgCyan).Printf("----> %v", r.Name)
-			} else {
-				color.New(color.FgRed).Printf("----> %v", r.Name)
-			}
 			tests++
 			if !r.Success {
 				success = false
 				failures++
+			}
+			if r.Skipped {
+				color.New(color.FgYellow).Printf("----> %v", r.Name)
+				skipped++
+				continue
+			}
+			if r.Success {
+				color.New(color.FgCyan).Printf("----> %v", r.Name)
+			} else {
+				color.New(color.FgRed).Printf("----> %v", r.Name)
 			}
 			if r.Errors != nil {
 				for _, e := range r.Errors {
@@ -447,7 +452,7 @@ suites:
 
 	if !success {
 		color.New(color.BgHiRed, color.Bold, color.FgBlack).Printf(" FAIL! ")
-		fmt.Printf(" %d of %d tests failed.\n", failures, tests)
+		fmt.Printf(" %d of %d tests failed (%d implicit).\n", failures, tests, skipped)
 		return 1
 	}
 


### PR DESCRIPTION
If a required test fails, all subsequent tests in the same suite fail implicitly. A test case can be marked as required by setting the new `require` property to `true`.

```yml
-
  require: true
  request:
    method: GET
    url: http://www.example.com/NOT_FOUND
  response:
    status: 200
```