### PR TITLE
Test results caching

### DIFF
--- a/example/simple.yml
+++ b/example/simple.yml
@@ -1,0 +1,8 @@
+
+-
+  request:
+    method: GET
+    url: https://raw.githubusercontent.com/instaunit/instaunit/NOT_FOUND
+  
+  response:
+    status: 404

--- a/src/hunit/cache/cache.go
+++ b/src/hunit/cache/cache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	pathutil "path"
 
@@ -38,6 +39,7 @@ func Checksum(path string) (*Resource, error) {
 
 type Cache struct {
 	Version string                     `json:"version"`
+	Created time.Time                  `json:"created"`
 	Binary  *Resource                  `json:"binary,omitempty"`
 	Suites  []*Resource                `json:"suites,omitempty"`
 	Results map[string][]*hunit.Result `json:"results,omitempty"` // checksum -> []results

--- a/src/hunit/cache/cache.go
+++ b/src/hunit/cache/cache.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/instaunit/instaunit/hunit"
@@ -17,14 +18,14 @@ type Resource struct {
 func Checksum(path string) (*Resource, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer f.Close()
 
 	h := md5.New()
 	_, err = io.Copy(h, f)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	return &Resource{
@@ -38,6 +39,11 @@ type Cache struct {
 	Binary  *Resource                  `json:"binary,omitempty"`
 	Suites  []*Resource                `json:"suites,omitempty"`
 	Results map[string][]*hunit.Result `json:"results,omitempty"`
+	suites  map[string]*Resource
+}
+
+func (c *Cache) Suite(path string) *Resource {
+	return c.suites[path]
 }
 
 func Read(path string) (*Cache, error) {
@@ -46,18 +52,25 @@ func Read(path string) (*Cache, error) {
 		return nil, err
 	}
 	defer f.Close()
+
 	c := &Cache{}
 	err = json.NewDecoder(f).Decode(c)
 	if err != nil {
 		return nil, err
 	}
+
+	c.suites = make(map[string]*Resource)
+	for _, e := range c.Suites {
+		c.suites[e.Path] = e
+	}
+
 	return c, nil
 }
 
 func Write(path string, cache *Cache) error {
 	f, err := os.Create(path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer f.Close()
 	return json.NewEncoder(f).Encode(cache)

--- a/src/hunit/cache/cache.go
+++ b/src/hunit/cache/cache.go
@@ -1,0 +1,64 @@
+package cache
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/instaunit/instaunit/hunit"
+)
+
+type Resource struct {
+	Path     string `json:"path"`
+	Checksum string `json:"checksum"`
+}
+
+func Checksum(path string) (*Resource, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := md5.New()
+	_, err = io.Copy(h, f)
+	if err != nil {
+		return "", err
+	}
+
+	return &Resource{
+		Path:     path,
+		Checksum: fmt.Sprintf("%x", h.Sum(nil)),
+	}, nil
+}
+
+type Cache struct {
+	Version string                     `json:"version"`
+	Binary  *Resource                  `json:"binary,omitempty"`
+	Suites  []*Resource                `json:"suites,omitempty"`
+	Results map[string][]*hunit.Result `json:"results,omitempty"`
+}
+
+func Read(path string) (*Cache, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	c := &Cache{}
+	err = json.NewDecoder(f).Decode(c)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func Write(path string, cache *Cache) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return json.NewEncoder(f).Encode(cache)
+}

--- a/src/hunit/cache/cache.go
+++ b/src/hunit/cache/cache.go
@@ -47,7 +47,11 @@ type Cache struct {
 }
 
 func (c *Cache) Suite(checksum string) *Resource {
-	return c.suites[checksum]
+	if c.suites != nil {
+		return c.suites[checksum]
+	} else {
+		return nil
+	}
 }
 
 func (c *Cache) AddSuite(suite *Resource, results []*hunit.Result) {

--- a/src/hunit/report/emit/junit/junit.go
+++ b/src/hunit/report/emit/junit/junit.go
@@ -104,7 +104,7 @@ func (g *Generator) Suite(conf test.Config, suite *test.Suite, results *emit.Res
 			for _, err := range e.Errors {
 				tf = append(tf, testfail{
 					Type:   severityError,
-					Detail: err.Error(),
+					Detail: err,
 				})
 			}
 		} else if !e.Success {

--- a/src/hunit/result.go
+++ b/src/hunit/result.go
@@ -6,12 +6,13 @@ import (
 
 // A test result
 type Result struct {
-	Name             string
-	Success          bool
-	Skipped          bool
-	Errors           []error
-	Reqdata, Rspdata []byte
-	Runtime          time.Duration
+	Name    string        `json:"name"`
+	Success bool          `json:"success"`
+	Skipped bool          `json:"skipped"`
+	Errors  []string      `json:"errors,omitempty"`
+	Reqdata []byte        `json:"request_data,omitempty"`
+	Rspdata []byte        `json:"response_data,omitempty"`
+	Runtime time.Duration `json:"duration"`
 }
 
 // Assert equality. If the values are not equal an error is added to the result.
@@ -28,6 +29,6 @@ func (r *Result) AssertEqual(e, a interface{}, m string, x ...interface{}) bool 
 // the result is returned so calls can be chained.
 func (r *Result) Error(e error) *Result {
 	r.Success = false
-	r.Errors = append(r.Errors, e)
+	r.Errors = append(r.Errors, e.Error())
 	return r
 }

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	stdinPath = "-"
-	cacheBase = "./.hunit/cache"
+	cacheBase = "./.instaunit/cache"
 )
 
 var ( // set at compile time via the linker

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -506,8 +506,8 @@ suites:
 
 func reportResults(options test.Options, cached bool, results []*hunit.Result, tests, failures, skipped *int) bool {
 	var count int
-	var success bool
 	var prefix string
+	success := true
 	if cached {
 		prefix = "(cached) "
 	}

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -267,6 +267,8 @@ func app() int {
 		} else if b := c.Binary; b != nil && b.Path == *fExec && b.Checksum == sum.Checksum {
 			fmt.Println("----> Using results cache:", cachePath)
 			rcache = c
+		} else {
+			fmt.Println("----> Results cache is outdated:", cachePath)
 		}
 	}
 

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/instaunit/instaunit/hunit"
+	"github.com/instaunit/instaunit/hunit/cache"
 	"github.com/instaunit/instaunit/hunit/doc"
 	"github.com/instaunit/instaunit/hunit/exec"
 	"github.com/instaunit/instaunit/hunit/net/await"
@@ -385,7 +386,7 @@ suites:
 			if r.Errors != nil {
 				for _, e := range r.Errors {
 					count++
-					fmt.Println(text.IndentWithOptions(fmt.Sprintf("        #%d %v", count, e), "             ", 0))
+					fmt.Println(text.IndentWithOptions(fmt.Sprintf("        #%d %s", count, e), "             ", 0))
 					fmt.Println()
 				}
 			}

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -317,9 +317,7 @@ suites:
 		}
 
 		if suite.Title != "" {
-			color.New(colorSuite...).Printf(" (%v)\n", suite.Title)
-		} else {
-			fmt.Println()
+			color.New(colorSuite...).Printf(" (%v)", suite.Title)
 		}
 
 		var sum *cache.Resource
@@ -330,6 +328,9 @@ suites:
 				errno++
 				break
 			}
+			color.New(colorSuite...).Printf(" (cache: %s)\n", sum.Checksum)
+		} else {
+			fmt.Println()
 		}
 
 		if rcache != nil && e != stdinPath {
@@ -337,7 +338,7 @@ suites:
 			if cached != nil {
 				fmt.Println("----> Reporting cached results from:", rcache.Created)
 				results := rcache.ResultsForSuite(sum)
-				success = success && reportResults(options, true, results, &tests, &failures, &skipped)
+				success = reportResults(options, true, results, &tests, &failures, &skipped) && success
 				wcache.AddSuite(cached, results)
 				continue
 			}
@@ -427,7 +428,7 @@ suites:
 			}
 		}
 
-		success = success && reportResults(options, false, results, &tests, &failures, &skipped)
+		success = reportResults(options, false, results, &tests, &failures, &skipped) && success
 		if wcache != nil && sum != nil {
 			wcache.AddSuite(sum, results)
 		}

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -326,7 +326,7 @@ suites:
 		if (rcache != nil || wcache != nil) && e != stdinPath {
 			sum, err = cache.Checksum(e)
 			if err != nil {
-				color.New(colorErr...).Println("* * * Could not load suite checksum:", err)
+				color.New(colorErr...).Println("\n* * * Could not load suite checksum:", err)
 				errno++
 				break
 			}


### PR DESCRIPTION
Adds support for caching test results between runs. To enable caching, you must:

- Run your test suites against a managed service, and
- Enable caching via the new `-cache` flag.

## How Caching Works

Cached results are stored relative to the managed service that tests are run against. For a given managed service, a checksum of the service binary itself, a checksum of each input test suite file, and the results reported for each test suite are stored in a cache file.

When Instaunit is run with caching enabled, it performs these checks:

1. It first checks to see if a cache exists for the managed service.
2. If so, it checks to see if the managed service binary has the same checksum as the binary that was used to generate the cached results.
3. Instaunit then loads each tests suite file as it would normally, and for each test suite:
4. It computes the checksum of the test suite data, and then checks to see if there are cached results for that checksum.

In the event that all these checks are true, both the managed service binary that is being tested and the tests themselves have not changed from a previous run. Instaunit reports all the cached results for that test suite instead of actually running the tests.

If any of these checks are not true, Instaunit runs the tests as if caching were not enabled, but it caches the results of the tests for future use.

If the managed service has not changed but some of the test suites have, Instaunit will report cached results for the suites that have not changed and run the suites that have changed. Caching results at the level of an individual test case is not supported.

## Caveats

Note that this method of caching relies on a checksum of the managed service binary for proof that the service being tested has not changed. This means that caching is not suitable for services that aren't a single binary.

It is not possible for Instaunit to know if your service loads executable code at runtime which may alter its behavior in a way that would render cached results invalid. You should not use caching in these circumstances.

Future versions of this caching mechanism may explore alternative approaches for determining whether a managed service has changed, such as allowing the user to provide an explicit cache key for the service as a parameter. This could, for example, be used to pass in a Git hash or some other proxy for the state of the managed service artifact.

## Cache Files

The cache file is located relative to the directory where Instaunit is invoke at the path:

```
./instaunit/cache/{path_to_managed_service}.cache
```

For example, if Instaunit is invoked as:

```
$ instaunit -exec path/to/service -cache a.yml b.yml
```

The cache for this binary will be located at:

```
./instaunit/cache/path/to/service.cache
```
