### PR TITLE
Add time and JSON functions to expression stdlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ install: build ## Build and install
 	install -m 0755 $(TARGET_DIR)/bin/$(NAME) $(PREFIX)/bin/
 
 test: ## Run tests
-	(cd src && go test $(TEST_PKGS))
+	(cd src && go test $(FLAGS) $(TEST_PKGS))
 
 clean: ## Delete the built product and any generated files
 	rm -rf $(BUILD_DIR)

--- a/example/stdlib.yml
+++ b/example/stdlib.yml
@@ -1,0 +1,42 @@
+
+- 
+  id: first
+  
+  request:
+    method: GET
+    url: https://www.google.com
+    params:
+      a: ${std.Base64.Encode("This is a string to encode.")}
+  
+  response:
+    status: 200
+
+- 
+  request:
+    method: POST
+    url: https://www.google.com
+    entity: |
+      ${std.JSON.Marshal(first.response.headers)}
+  
+  response:
+    status: 405
+
+- 
+  request:
+    method: POST
+    url: https://www.google.com
+    entity: |
+      ${std.JSON.Unmarshal(std.JSON.Marshal(first.response.headers))}
+  
+  response:
+    status: 405
+
+- 
+  request:
+    method: POST
+    url: https://www.google.com
+    entity: |
+      ${std.JSON.Unmarshal("{\\"a\\":\\"OKOKOK\\"\}")}
+  
+  response:
+    status: 200

--- a/src/hunit/expr/expr.go
+++ b/src/hunit/expr/expr.go
@@ -10,6 +10,10 @@ import (
 	"github.com/bww/epl"
 )
 
+var (
+	ErrEndOfInput = fmt.Errorf("Unexpected end-of-input")
+)
+
 // Variables
 type Variables map[string]interface{}
 
@@ -51,63 +55,67 @@ func interpolate(s, pre, suf string, context interface{}) (string, error) {
 	fp := pre[0]
 	fs := suf[0]
 
-	var out string
-	var i, esc int
+	out := &strings.Builder{}
+	var expr *strings.Builder
+	var i, esc, start int
+
 	for {
 		if i >= len(s) {
-			break
+			if expr != nil {
+				return "", ErrEndOfInput
+			} else {
+				break
+			}
 		}
 
 		if s[i] == '\\' {
 			esc++
 			if (esc % 2) == 0 {
-				out += "\\"
+				out.WriteRune('\\')
 			}
 			i++
 			continue
 		}
 
-		if s[i] == fp && (esc%2) == 0 && matchAhead(s[i:], pre) {
-			i += len(pre)
-			start := i
-			for {
-				if i >= len(s) {
-					return "", fmt.Errorf("Unexpected end-of-input")
+		if expr != nil {
+			if s[i] == fs && (esc%2) == 0 && matchAhead(s[i:], suf) {
+				prg, err := epl.Compile(expr.String())
+				if err != nil {
+					return "", err
 				}
-				if s[i] == fs && matchAhead(s[i:], suf) {
 
-					prg, err := epl.Compile(s[start:i])
-					if err != nil {
-						return "", err
-					}
-
-					res, err := prg.Exec(context)
-					if err != nil {
-						return "", fmt.Errorf("Could not evaluate expression: {%v}: %v", s[start:i], err)
-					}
-
-					switch v := res.(type) {
-					case string:
-						out += v
-					default:
-						out += fmt.Sprintf("%v", v)
-					}
-
-					i += len(suf)
-					break
-				} else {
-					i++
+				res, err := prg.Exec(context)
+				if err != nil {
+					return "", fmt.Errorf("Could not evaluate expression: {%v}: %v", s[start:i], err)
 				}
+
+				switch v := res.(type) {
+				case string:
+					out.WriteString(v)
+				default:
+					out.WriteString(fmt.Sprint(v))
+				}
+
+				i += len(suf)
+				start = 0
+				expr = nil
+			} else {
+				expr.WriteByte(s[i])
+				i++
 			}
+		} else if s[i] == fp && (esc%2) == 0 && matchAhead(s[i:], pre) {
+			i += len(pre)
+			start = i
+			expr = &strings.Builder{}
 		} else {
-			out += string(s[i])
+			out.WriteByte(s[i])
 			i++
 		}
 
 		esc = 0
 	}
 
-	return out, nil
+	return out.String(), nil
 }
 
 // Match ahead

--- a/src/hunit/expr/expr.go
+++ b/src/hunit/expr/expr.go
@@ -71,7 +71,11 @@ func interpolate(s, pre, suf string, context interface{}) (string, error) {
 		if s[i] == '\\' {
 			esc++
 			if (esc % 2) == 0 {
-				out.WriteRune('\\')
+				if expr != nil {
+					expr.WriteRune('\\')
+				} else {
+					out.WriteRune('\\')
+				}
 			}
 			i++
 			continue

--- a/src/hunit/expr/expr_test.go
+++ b/src/hunit/expr/expr_test.go
@@ -28,7 +28,13 @@ func TestInterpolateVariables(t *testing.T) {
 			`Before ${a}, after.`, `Before 123, after.`, nil,
 		},
 		{
+			`Before ${a}, ${b} after.`, `Before 123, String value after.`, nil,
+		},
+		{
 			`Before ${"\}"}, after.`, `Before }, after.`, nil,
+		},
+		{
+			`Before ${"\}"}, ${b} after.`, `Before }, String value after.`, nil,
 		},
 		{
 			`Before ${""}}, after.`, `Before }, after.`, nil,
@@ -40,10 +46,13 @@ func TestInterpolateVariables(t *testing.T) {
 			`Before \\${a}, after.`, `Before \123, after.`, nil,
 		},
 		{
-			`Before $${a}}, after.`, `Before $123}, after.`, nil,
+			`Before \\${a}${b}, after.`, `Before \123String value, after.`, nil,
 		},
 		{
 			`Before $${a}}, after.`, `Before $123}, after.`, nil,
+		},
+		{
+			`Before $${a}, ${b} after.`, `Before $123, String value after.`, nil,
 		},
 		{
 			`Before ${c.a[0]}, after.`, `Before Zero, after.`, nil,

--- a/src/hunit/expr/expr_test.go
+++ b/src/hunit/expr/expr_test.go
@@ -1,13 +1,9 @@
 package expr
 
 import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
-)
 
-var (
-	invalidInputError = fmt.Errorf("Invalid input")
+	"github.com/stretchr/testify/assert"
 )
 
 var context = map[string]interface{}{
@@ -23,36 +19,56 @@ var context = map[string]interface{}{
  * Test interpolate
  */
 func TestInterpolateVariables(t *testing.T) {
-	testInterpolate(t, `Before ${a}, after.`, `Before 123, after.`, context)
-	testInterpolate(t, `Before \${a}, after.`, `Before ${a}, after.`, context)
-	testInterpolate(t, `Before \\${a}, after.`, `Before \123, after.`, context)
-	testInterpolate(t, `Before $${a}}, after.`, `Before $123}, after.`, context)
-	testInterpolate(t, `Before $${a}}, after.`, `Before $123}, after.`, context)
-	testInterpolate(t, `Before ${c.a[0]}, after.`, `Before Zero, after.`, context)
-	testInterpolate(t, `Before ${c["b"]}, after.`, `Before false, after.`, context)
-	testInterpolate(t, `Before ${a, after.`, invalidInputError, context)
-	testInterpolate(t, `Before ${a
-}, after.`, `Before 123, after.`, context) // whitespace is not significant in EPL
+	tests := []struct {
+		Text   string
+		Expect string
+		Error  error
+	}{
+		{
+			`Before ${a}, after.`, `Before 123, after.`, nil,
+		},
+		{
+			`Before ${"\}"}, after.`, `Before }, after.`, nil,
+		},
+		{
+			`Before ${""}}, after.`, `Before }, after.`, nil,
+		},
+		{
+			`Before \${a}, after.`, `Before ${a}, after.`, nil,
+		},
+		{
+			`Before \\${a}, after.`, `Before \123, after.`, nil,
+		},
+		{
+			`Before $${a}}, after.`, `Before $123}, after.`, nil,
+		},
+		{
+			`Before $${a}}, after.`, `Before $123}, after.`, nil,
+		},
+		{
+			`Before ${c.a[0]}, after.`, `Before Zero, after.`, nil,
+		},
+		{
+			`Before ${a, after.`, "", ErrEndOfInput,
+		},
+		{
+			`Before ${a
+}, after.`, `Before 123, after.`, nil,
+		},
+	}
+	for _, e := range tests {
+		testInterpolate(t, e.Text, e.Expect, e.Error, context)
+	}
 }
 
-func testInterpolate(t *testing.T, s string, e, c interface{}) {
+func testInterpolate(t *testing.T, s string, e string, r error, c interface{}) {
 	t.Logf("----> %v\n", s)
-
 	v, err := interpolate(s, "${", "}", c)
-	if e == invalidInputError {
-		if assert.NotNil(t, err, "Expect an error") {
-			t.Logf("(err) %v\n", err)
-		}
-		return
+	if r != nil {
+		t.Logf("<---- (ERR) %v\n", err)
+		assert.Equal(t, r, err, s)
 	} else {
-		if !assert.Nil(t, err, fmt.Sprintf("%v", err)) {
-			return
-		}
+		t.Logf("<---- %v\n", v)
+		assert.Equal(t, e, v)
 	}
-
-	t.Logf("<---- %v\n", v)
-	if !assert.Equal(t, e, v) {
-		return
-	}
-
 }

--- a/src/hunit/expr/runtime/json.go
+++ b/src/hunit/expr/runtime/json.go
@@ -1,0 +1,35 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// json libs
+type stdJSON struct{}
+
+func (s stdJSON) Marshal(v interface{}) (string, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (s stdJSON) Unmarshal(v interface{}) (interface{}, error) {
+	var data []byte
+	switch c := v.(type) {
+	case []byte:
+		data = c
+	case string:
+		data = []byte(c)
+	default:
+		return nil, fmt.Errorf("Unsupported type: %T", v)
+	}
+	var obj interface{}
+	err := json.Unmarshal(data, &obj)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/src/hunit/expr/runtime/stdlib.go
+++ b/src/hunit/expr/runtime/stdlib.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/bww/epl"
 	"github.com/bww/go-util/rand"
@@ -19,6 +20,7 @@ func deprecated(a, b string) {
 // The standard library
 type stdlib struct {
 	Base64 stdBase64
+	JSON   stdJSON
 }
 
 // Builtins
@@ -88,6 +90,11 @@ func (s stdlib) ToTitle(v string) string {
 // Trim space from both ends of a string
 func (s stdlib) TrimSpace(v string) string {
 	return strings.TrimSpace(v)
+}
+
+// Get the current timestamp as time.Time
+func (s stdlib) Now() time.Time {
+	return time.Now()
 }
 
 // Take any element from a collection


### PR DESCRIPTION
## JSON handling
The following methods have been added to the expression standard library:

- `std.JSON.Marshal(any) string`, to marshal an entity to JSON
- `std.JSON.Unmarshal(string) any`, to unmarshal a string to an object

These functions allow for object graphs to be literalized in a test suit. As a contrived example, we could assert that two different responses are exactly identical:

```yaml
-
  id: first

  request:
    method: GET
    url: /endpoint

  response:
    status: 200

-
  request:
    method: GET
    url: /endpoint

  response:
    status: 200
    entity: |
      ${std.JSON.Marshal(first.response.value)}
```

## Time handling
The following methods have been added to the expression standard library:

- `std.Now() time.Time`, to get the current time

Since the returned value is a time.Time, it can be operated on to do common date manipulation tasks:

```
The unix timestamp is: ${std.Now().Unix()}.
```

## Expression parsing
Expression parsing was improved. Escape sequences in expressions are now handled correctly.
