### PR TITLE
Adding basic suite introspection functionality

### DIFF
--- a/example/simple.yml
+++ b/example/simple.yml
@@ -1,11 +1,10 @@
 
-tests:
-  -
-    request:
-      method: GET
-      url: https://raw.githubusercontent.com/instaunit/instaunit/NOT_FOUND
-      params:
-        first: ${"A"+"B"}
-    
-    response:
-      status: 400
+-
+  request:
+    method: GET
+    url: https://raw.githubusercontent.com/instaunit/instaunit/NOT_FOUND
+    params:
+      first: ${"A"+"B"}
+  
+  response:
+    status: 400

--- a/example/simple.yml
+++ b/example/simple.yml
@@ -1,10 +1,11 @@
 
--
-  request:
-    method: GET
-    url: https://raw.githubusercontent.com/instaunit/instaunit/NOT_FOUND
-    params:
-      first: ${"A"+"B"}
-  
-  response:
-    status: 400
+tests:
+  -
+    request:
+      method: GET
+      url: https://raw.githubusercontent.com/instaunit/instaunit/NOT_FOUND
+      params:
+        first: ${"A"+"B"}
+    
+    response:
+      status: 400

--- a/example/simple.yml
+++ b/example/simple.yml
@@ -1,10 +1,14 @@
 
 -
+  vars:
+    hello: Hello world
+  
   request:
     method: GET
     url: https://raw.githubusercontent.com/instaunit/instaunit/NOT_FOUND
     params:
       first: ${"A"+"B"}
+      second: ${vars.hello}
   
   response:
     status: 400

--- a/src/go.mod
+++ b/src/go.mod
@@ -19,4 +19,5 @@ require (
 	golang.org/x/text v0.3.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -49,3 +49,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -163,7 +163,7 @@ func RunTest(c test.Case, context Context) (*Result, FutureResult, error) {
 	}
 
 	// start with an unevaluated result
-	result := &Result{Name: fmt.Sprintf("%v %v\n", c.Request.Method, c.Request.URL), Success: true}
+	result := &Result{Name: formatName(c, c.Request.Method, c.Request.URL), Success: true}
 	defer func() {
 		result.Runtime = time.Since(start)
 	}()
@@ -194,7 +194,7 @@ func RunTest(c test.Case, context Context) (*Result, FutureResult, error) {
 	}
 
 	// incrementally update the name as we evaluate it
-	result.Name = fmt.Sprintf("%v %v\n", method, c.Request.URL)
+	result.Name = formatName(c, method, c.Request.URL)
 
 	var url string
 	if isAbsoluteURL(c.Request.URL) {
@@ -211,7 +211,7 @@ func RunTest(c test.Case, context Context) (*Result, FutureResult, error) {
 	}
 
 	// incrementally update the name as we evaluate it
-	result.Name = fmt.Sprintf("%v %v\n", method, url)
+	result.Name = formatName(c, method, url)
 
 	url, err = interpolateIfRequired(context, url)
 	if err != nil {
@@ -221,7 +221,7 @@ func RunTest(c test.Case, context Context) (*Result, FutureResult, error) {
 	}
 
 	// incrementally update the name as we evaluate it
-	result.Name = fmt.Sprintf("%v %v\n", method, url)
+	result.Name = formatName(c, method, url)
 
 	header := make(http.Header)
 	if context.Headers != nil {
@@ -469,6 +469,10 @@ func RunTest(c test.Case, context Context) (*Result, FutureResult, error) {
 	}
 
 	return result, nil, nil
+}
+
+func formatName(c test.Case, method, url string) string {
+	return fmt.Sprintf("%v %v @ line %d\n", method, url, c.Source.Line)
 }
 
 // Flatten a header to a one-to-one key-to-value map

--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -170,9 +170,9 @@ func RunTest(c test.Case, context Context) (*Result, FutureResult, error) {
 
 	// process variables first, they can be referenced by this case, itself
 	var vars map[string]interface{}
-	for _, e := range c.Vars {
-		k, v := e.Key.(string), gtext.Stringer(e.Value)
-		e, err := interpolateIfRequired(context, v)
+	for k, e := range c.Vars {
+		v := gtext.Stringer(e)
+		r, err := interpolateIfRequired(context, v)
 		if err != nil {
 			return result.Error(err), nil, nil
 		}
@@ -182,7 +182,7 @@ func RunTest(c test.Case, context Context) (*Result, FutureResult, error) {
 			vars = make(map[string]interface{})
 			context.Variables[localVarsId] = vars
 		}
-		vars[k] = e
+		vars[k] = r
 	}
 
 	// update the method

--- a/src/hunit/test/suite.go
+++ b/src/hunit/test/suite.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"time"
 
-	// "github.com/davecgh/go-spew/spew"
 	"github.com/instaunit/instaunit/hunit/exec"
 
 	yaml "gopkg.in/yaml.v3"

--- a/src/hunit/test/test.go
+++ b/src/hunit/test/test.go
@@ -64,6 +64,17 @@ type MessageExchange struct {
 	Input  *string       `yaml:"receive"`
 }
 
+// Source comments
+type Comments struct {
+	Head, Line, Tail string
+}
+
+// Source annotation
+type Source struct {
+	Line, Column int
+	Comments     Comments
+}
+
 // A test case
 type Case struct {
 	Id         string                 `yaml:"id"`
@@ -79,6 +90,7 @@ type Case struct {
 	Response   Response               `yaml:"response"`
 	Stream     *Stream                `yaml:"websocket"`
 	Vars       map[string]interface{} `yaml:"vars"`
+	Source     Source
 }
 
 // Determine if this case is documented or not

--- a/src/hunit/test/test.go
+++ b/src/hunit/test/test.go
@@ -2,8 +2,7 @@ package test
 
 import (
 	"time"
-
-	yaml "gopkg.in/yaml.v2"
+	// yaml "gopkg.in/yaml.v3"
 )
 
 // Options
@@ -67,19 +66,19 @@ type MessageExchange struct {
 
 // A test case
 type Case struct {
-	Id         string            `yaml:"id"`
-	Wait       time.Duration     `yaml:"wait"`
-	Repeat     int               `yaml:"repeat"`
-	Concurrent int               `yaml:"concurrent"`
-	Gendoc     bool              `yaml:"gendoc"`
-	Title      string            `yaml:"title"`
-	Comments   string            `yaml:"doc"`
-	Require    bool              `yaml:"require"`
-	Params     map[string]string `yaml:"params"`
-	Request    Request           `yaml:"request"`
-	Response   Response          `yaml:"response"`
-	Stream     *Stream           `yaml:"websocket"`
-	Vars       yaml.MapSlice     `yaml:"vars"`
+	Id         string                 `yaml:"id"`
+	Wait       time.Duration          `yaml:"wait"`
+	Repeat     int                    `yaml:"repeat"`
+	Concurrent int                    `yaml:"concurrent"`
+	Gendoc     bool                   `yaml:"gendoc"`
+	Title      string                 `yaml:"title"`
+	Comments   string                 `yaml:"doc"`
+	Require    bool                   `yaml:"require"`
+	Params     map[string]string      `yaml:"params"`
+	Request    Request                `yaml:"request"`
+	Response   Response               `yaml:"response"`
+	Stream     *Stream                `yaml:"websocket"`
+	Vars       map[string]interface{} `yaml:"vars"`
 }
 
 // Determine if this case is documented or not


### PR DESCRIPTION
Test cases now have some information about their location in the YAML file in which they were defined. This allows us to report the line number that a test case occurred on, which can be very helpful in identifying a particular test.
