### PR TITLE
Evaluate expressions in test case url

### DIFF
--- a/src/go.sum
+++ b/src/go.sum
@@ -51,6 +51,7 @@ github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVU
 golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e h1:nFYrTHrdrAOpShe27kaFHjsqYSEQ0KWqdWLu3xuZJts=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -211,15 +211,17 @@ func RunTest(c test.Case, context Context) (*Result, FutureResult, expr.Variable
 		return nil, nil, nil, fmt.Errorf("Request requires a method (set 'method')")
 	}
 
-	// incrementally update the name as we evaluate it
-	result.Name = formatName(c, method, c.Request.URL)
-
-	var url string
-	if isAbsoluteURL(c.Request.URL) {
-		url = c.Request.URL
-	} else {
-		url = joinPath(context.BaseURL, c.Request.URL)
+	// update the url
+	url, err := interpolateIfRequired(context, c.Request.URL)
+	if err != nil {
+		return result.Error(err), nil, vars, nil
 	}
+	if !isAbsoluteURL(url) {
+		url = joinPath(context.BaseURL, url)
+	}
+
+	// incrementally update the name as we evaluate it
+	result.Name = formatName(c, method, url)
 
 	if len(c.Request.Params) > 0 {
 		url, err = mergeQueryParams(url, c.Request.Params, context)

--- a/src/hunit/script/script_test.go
+++ b/src/hunit/script/script_test.go
@@ -86,7 +86,7 @@ func TestScripts(t *testing.T) {
 		{
 			Script{"epl", `"Not a bool"`},
 			false,
-			ErrInvalidTypeError{`"Not a bool"`, "bool", "Not a bool"},
+			InvalidTypeError{`"Not a bool"`, "bool", "Not a bool"},
 		},
 		{
 			Script{"epl", `c.b`},


### PR DESCRIPTION
Corrects an issue where expressions were not evaluated in the test case URL field (although they were in the method).