### PR TITLE
Quiet mode

### DIFF
--- a/src/hunit/exec/cmd.go
+++ b/src/hunit/exec/cmd.go
@@ -15,6 +15,16 @@ import (
 
 const newline = '\n'
 
+// A writer that discards output
+type discardWriter struct{}
+
+func (s discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (s discardWriter) Close() error                { return nil }
+
+func NewDiscardWriter() discardWriter {
+	return discardWriter{}
+}
+
 // A writer that indents lines with a prefix string
 type prefixWriter struct {
 	writer io.Writer

--- a/src/hunit/test/test.go
+++ b/src/hunit/test/test.go
@@ -7,17 +7,22 @@ import (
 )
 
 // Options
-type Options uint32
+type Options uint64
+
+func (o Options) On(v int) bool {
+	return (o & Options(v)) == Options(v)
+}
 
 const (
-	OptionNone                         = 0
-	OptionDebug                        = 1 << 0
-	OptionEntityTrimTrailingWhitespace = 1 << 1
-	OptionInterpolateVariables         = 1 << 2
-	OptionDisplayRequests              = 1 << 3
-	OptionDisplayResponses             = 1 << 4
-	OptionDisplayRequestsOnFailure     = 1 << 5
-	OptionDisplayResponsesOnFailure    = 1 << 6
+	OptionNone                         = iota
+	OptionDebug                        = 1 << iota
+	OptionQuiet                        = 1 << iota
+	OptionEntityTrimTrailingWhitespace = 1 << iota
+	OptionInterpolateVariables         = 1 << iota
+	OptionDisplayRequests              = 1 << iota
+	OptionDisplayResponses             = 1 << iota
+	OptionDisplayRequestsOnFailure     = 1 << iota
+	OptionDisplayResponsesOnFailure    = 1 << iota
 )
 
 // Basic credentials

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -559,10 +559,10 @@ func reportResults(options test.Options, cached bool, results []*hunit.Result, t
 			*skipped++
 			continue
 		}
-		if r.Success && !quiet {
-			color.New(color.FgCyan).Printf("----> %s%v", prefix, r.Name)
-		} else if !r.Success {
+		if !r.Success {
 			color.New(color.FgRed).Printf("----> %s%v", prefix, r.Name)
+		} else if !options.On(test.OptionQuiet) {
+			color.New(color.FgCyan).Printf("----> %s%v", prefix, r.Name)
 		}
 		if r.Errors != nil {
 			for _, e := range r.Errors {


### PR DESCRIPTION
This adds support for a "quiet mode". When enabled, minimal output is logged on success and output is logged as normal on failure.