### PR TITLE
Adding support for per-route stats

### DIFF
--- a/src/hunit/doc/doc.go
+++ b/src/hunit/doc/doc.go
@@ -3,7 +3,6 @@ package doc
 import (
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/instaunit/instaunit/hunit/doc/emit"
 	"github.com/instaunit/instaunit/hunit/doc/emit/markdown"
@@ -13,7 +12,7 @@ import (
 // Implemented by documentation generators
 type Generator interface {
 	Init(*test.Suite) error
-	Case(test.Config, test.Case, *http.Request, string, *http.Response, []byte) error
+	Case(test.Config, emit.Case) error
 	Finalize(*test.Suite) error
 	Close() error
 }

--- a/src/hunit/doc/emit/emit.go
+++ b/src/hunit/doc/emit/emit.go
@@ -2,7 +2,21 @@ package emit
 
 import (
 	"fmt"
+	"net/http"
+
+	"github.com/instaunit/instaunit/hunit/route"
+	"github.com/instaunit/instaunit/hunit/test"
 )
+
+// A test case to be documented
+type Case struct {
+	Case     test.Case
+	Route    *route.Route
+	Request  *http.Request
+	Reqdata  []byte
+	Response *http.Response
+	Rspdata  []byte
+}
 
 // Documentation format type
 type Doctype uint32

--- a/src/hunit/doc/emit/markdown/markdown.go
+++ b/src/hunit/doc/emit/markdown/markdown.go
@@ -119,7 +119,7 @@ func (g *Generator) generate(w io.Writer, conf test.Config, c emit.Case) error {
 	if c.Case.Title != "" {
 		t = strings.TrimSpace(c.Case.Title)
 	} else if c.Route != nil && c.Route.Name != "" {
-		t = fmt.Sprintf("%s %s", c.Case.Request.Method, c.Route.Name)
+		t = c.Route.Name
 	} else {
 		t = fmt.Sprintf("%s %s", c.Case.Request.Method, c.Case.Request.URL)
 	}

--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -388,6 +388,9 @@ func RunTest(c test.Case, context Context) (*Result, FutureResult, expr.Variable
 		return result.Error(err), nil, vars, nil
 	}
 
+	// note the result status
+	result.Status = rsp.StatusCode
+
 	// if we have route headers defined, add a route to the result
 	if id := rsp.Header.Get("X-Route-Id"); id != "" {
 		result.Route = &route.Route{

--- a/src/hunit/result.go
+++ b/src/hunit/result.go
@@ -62,6 +62,7 @@ type Stats struct {
 
 func NewStats(v []*Result) Stats {
 	s := make(map[string]RouteStats)
+	var rids []string
 
 	for _, e := range v {
 		if r := e.Route; r != nil {
@@ -70,6 +71,7 @@ func NewStats(v []*Result) Stats {
 			if t, ok = s[r.Id]; !ok {
 				t.Route = r
 				t.Statuses = make(map[int]StatusStats)
+				rids = append(rids, r.Id)
 			}
 			x := t.Statuses[e.Status]
 			x.Count++
@@ -81,8 +83,8 @@ func NewStats(v []*Result) Stats {
 	}
 
 	d := make([]RouteStats, 0, len(s))
-	for _, e := range s {
-		d = append(d, e)
+	for _, e := range rids {
+		d = append(d, s[e])
 	}
 
 	return Stats{

--- a/src/hunit/result.go
+++ b/src/hunit/result.go
@@ -2,6 +2,8 @@ package hunit
 
 import (
 	"time"
+
+	"github.com/instaunit/instaunit/hunit/route"
 )
 
 // A test result
@@ -9,9 +11,11 @@ type Result struct {
 	Name    string        `json:"name"`
 	Success bool          `json:"success"`
 	Skipped bool          `json:"skipped"`
+	Route   *route.Route  `json:"route,omitempty"`
 	Errors  []string      `json:"errors,omitempty"`
 	Reqdata []byte        `json:"request_data,omitempty"`
 	Rspdata []byte        `json:"response_data,omitempty"`
+	Status  int           `json:"status,omitempty"`
 	Context Context       `json:"context"`
 	Runtime time.Duration `json:"duration"`
 }

--- a/src/hunit/result.go
+++ b/src/hunit/result.go
@@ -39,10 +39,20 @@ func (r *Result) Error(e error) *Result {
 }
 
 // Route states
+type StatusStats struct {
+	Count   int           // request count
+	Runtime time.Duration // total request runtime
+}
+
+func (s StatusStats) AvgRuntime() time.Duration {
+	return s.Runtime / time.Duration(s.Count)
+}
+
+// Route states
 type RouteStats struct {
 	Route    *route.Route
-	Requests int         // request count
-	Statuses map[int]int // result status counts
+	Requests int                 // request count
+	Statuses map[int]StatusStats // result status counts
 }
 
 // Result set stats
@@ -59,11 +69,13 @@ func NewStats(v []*Result) Stats {
 			var ok bool
 			if t, ok = s[r.Id]; !ok {
 				t.Route = r
-				t.Statuses = make(map[int]int)
+				t.Statuses = make(map[int]StatusStats)
 			}
+			x := t.Statuses[e.Status]
+			x.Count++
+			x.Runtime += e.Runtime
 			t.Requests++
-			n := t.Statuses[e.Status]
-			t.Statuses[e.Status] = n + 1
+			t.Statuses[e.Status] = x
 			s[r.Id] = t
 		}
 	}

--- a/src/hunit/result.go
+++ b/src/hunit/result.go
@@ -37,3 +37,43 @@ func (r *Result) Error(e error) *Result {
 	r.Errors = append(r.Errors, e.Error())
 	return r
 }
+
+// Route states
+type RouteStats struct {
+	Route    *route.Route
+	Requests int         // request count
+	Statuses map[int]int // result status counts
+}
+
+// Result set stats
+type Stats struct {
+	Routes []RouteStats // distinct routes
+}
+
+func NewStats(v []*Result) Stats {
+	s := make(map[string]RouteStats)
+
+	for _, e := range v {
+		if r := e.Route; r != nil {
+			var t RouteStats
+			var ok bool
+			if t, ok = s[r.Id]; !ok {
+				t.Route = r
+				t.Statuses = make(map[int]int)
+			}
+			t.Requests++
+			n := t.Statuses[e.Status]
+			t.Statuses[e.Status] = n + 1
+			s[r.Id] = t
+		}
+	}
+
+	d := make([]RouteStats, 0, len(s))
+	for _, e := range s {
+		d = append(d, e)
+	}
+
+	return Stats{
+		Routes: d,
+	}
+}

--- a/src/hunit/route/route.go
+++ b/src/hunit/route/route.go
@@ -1,0 +1,7 @@
+package route
+
+// Describes a route in the service under test
+type Route struct {
+	Id   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -72,6 +73,7 @@ func app() int {
 		fDoctype         = cmdline.String("doc:type", coalesce(os.Getenv("HUNIT_DOC_TYPE"), "markdown"), "The format to generate documentation in. Overrides: $HUNIT_DOC_TYPE.")
 		fDocInclHTTP     = cmdline.Bool("doc:include-http", strToBool(os.Getenv("HUNIT_DOC_INCLUDE_HTTP")), "Include HTTP in request and response examples (as opposed to just routes and entities). Overrides: $HUNIT_DOC_INCLUDE_HTTP.")
 		fDocFormatEntity = cmdline.Bool("doc:format-entities", strToBool(os.Getenv("HUNIT_DOC_FORMAT_ENTITIES")), "Pretty-print supported request and response entities in documentation output. Overrides: $HUNIT_DOC_FORMAT_ENTITIES.")
+		fStats           = cmdline.Bool("stats", strToBool(os.Getenv("HUNIT_STATS")), "Display a smmary of stats for requests made in each test suite. Overrides: $HUNIT_STATS.")
 		fReport          = cmdline.Bool("report", strToBool(os.Getenv("HUNIT_REPORT")), "Generate a report. Overrides: $HUNIT_REPORT.")
 		fReportPath      = cmdline.String("report:output", coalesce(os.Getenv("HUNIT_REPORT_OUTPUT"), "./reports"), "The directory in which generated reports should be written. Overrides: $HUNIT_REPORT_OUTPUT.")
 		fReportType      = cmdline.String("report:type", coalesce(os.Getenv("HUNIT_REPORT_TYPE"), "junit"), "The format to generate reports in. Overrides: $HUNIT_REPORT_TYPE.")
@@ -470,25 +472,33 @@ suites:
 			wcache.AddSuite(sum, results)
 		}
 
-		stats := hunit.NewStats(results)
-		if len(stats.Routes) > 0 {
-			color.New(colorSuite...).Println("\n====> Summary")
-			for _, e := range stats.Routes {
-				fmt.Printf("----> %s\n", e.Route.Name)
-				var width int
-				labels := make(map[int]string)
-				for s, _ := range e.Statuses {
-					v := fmt.Sprintf("%d %s", s, http.StatusText(s))
-					labels[s] = v
-					if l := len(v); l > width {
-						width = l
+		if *fStats {
+			stats := hunit.NewStats(results)
+			if len(stats.Routes) > 0 {
+				color.New(colorSuite...).Println("====> Stats for", base)
+				for i, e := range stats.Routes {
+					if i > 0 {
+						fmt.Println()
+					}
+					fmt.Printf("----> %s\n", e.Route.Name)
+					var width int
+					var keys []int
+					labels := make(map[int]string)
+					for s, _ := range e.Statuses {
+						v := fmt.Sprintf("%d %s", s, http.StatusText(s))
+						keys = append(keys, s)
+						labels[s] = v
+						if l := len(v); l > width {
+							width = l
+						}
+					}
+					spec := fmt.Sprintf("%%-%ds", width)
+					sort.Ints(keys)
+					for _, s := range keys {
+						x := e.Statuses[s]
+						fmt.Printf("      "+spec+" %d requests, %v avg duration\n", labels[s], x.Count, x.AvgRuntime())
 					}
 				}
-				spec := fmt.Sprintf("%%%ds", width)
-				for s, x := range e.Statuses {
-					fmt.Printf("      "+spec+": %d cases, %v avg duration\n", labels[s], x.Count, x.AvgRuntime())
-				}
-				fmt.Println()
 			}
 		}
 

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -42,8 +42,9 @@ var ( // set at compile time via the linker
 )
 
 var (
-	colorErr   = []color.Attribute{color.FgYellow}
-	colorSuite = []color.Attribute{color.Bold}
+	colorErr    = []color.Attribute{color.FgYellow}
+	colorSuite  = []color.Attribute{color.Bold}
+	colorHeader = []color.Attribute{color.Bold}
 )
 
 var syncStdout = syncio.NewWriter(os.Stdout)
@@ -473,14 +474,19 @@ suites:
 		if len(stats.Routes) > 0 {
 			color.New(colorSuite...).Println("\n====> Summary")
 			for _, e := range stats.Routes {
-				fmt.Printf("----> %s ", e.Route.Name)
-				var i int
-				for s, n := range e.Statuses {
-					if i > 0 {
-						fmt.Print(", ")
+				fmt.Printf("----> %s\n", e.Route.Name)
+				var width int
+				labels := make(map[int]string)
+				for s, _ := range e.Statuses {
+					v := fmt.Sprintf("%d %s", s, http.StatusText(s))
+					labels[s] = v
+					if l := len(v); l > width {
+						width = l
 					}
-					fmt.Printf("%d: %d", s, n)
-					i++
+				}
+				spec := fmt.Sprintf("%%%ds", width)
+				for s, x := range e.Statuses {
+					fmt.Printf("      "+spec+": %d cases, %v avg duration\n", labels[s], x.Count, x.AvgRuntime())
 				}
 				fmt.Println()
 			}

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -469,6 +469,23 @@ suites:
 			wcache.AddSuite(sum, results)
 		}
 
+		stats := hunit.NewStats(results)
+		if len(stats.Routes) > 0 {
+			color.New(colorSuite...).Println("\n====> Summary")
+			for _, e := range stats.Routes {
+				fmt.Printf("----> %s ", e.Route.Name)
+				var i int
+				for s, n := range e.Statuses {
+					if i > 0 {
+						fmt.Print(", ")
+					}
+					fmt.Printf("%d: %d", s, n)
+					i++
+				}
+				fmt.Println()
+			}
+		}
+
 		if len(suite.Teardown) > 0 {
 			if execCommands(options, suite.Teardown) != nil {
 				continue suites

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -482,12 +482,8 @@ suites:
 						fmt.Println()
 					}
 					fmt.Printf("----> %s", e.Route.Name)
-					if d, _ := e.AvgRuntime(hunit.SuccessStatusFilter); d > 0 {
-						fmt.Printf(" (%v avg on success)\n", d)
-					} else {
-						fmt.Println()
-					}
 					if *fRoutesVerbose {
+						fmt.Println()
 						var width int
 						var keys []int
 						labels := make(map[int]string)
@@ -504,6 +500,10 @@ suites:
 						for _, s := range keys {
 							x := e.Statuses[s]
 							fmt.Printf("      "+spec+" %d requests, %v avg\n", labels[s], x.Count, x.AvgRuntime())
+						}
+					} else {
+						if d, n := e.AvgRuntime(hunit.SuccessStatusFilter); n > 0 {
+							fmt.Printf(" (%d successful @ %v avg)\n", n, d)
 						}
 					}
 				}


### PR DESCRIPTION
This adds a new feature to summarize stats for distinct routes, as defined by the service, optionally on a per-response-status basis. This summary is printed immediately after each test case's output.

```
$ instaunit -routes:verbose example.yml
====> example.yml
...
====> example.yml endpoint routes
----> POST /users/{user_id}/memberships
      200 OK           5 requests, 8.809568ms avg
      400 Bad Request  2 requests, 5.84955ms avg
      401 Unauthorized 1 requests, 727.274µs avg
      403 Forbidden    1 requests, 2.271408ms avg

...
```

This summary can be enabled via the new `-routes` flag (or `-routes:verbose` for a more verbose version). Or by setting the corresponding environment variables to anything: `HUNIT_ROUTES`, `HUNIT_ROUTES_VERBOSE`.

In order to use this feature, the service under test must support it. To do so, the service must add the following headers to the response of every supported request. These headers should describe the underlying, unique route that handles the URL, as opposed to the URL path itself, which may contain parameters or variables. The service determines what constitutes a distinct route for its purposes.

```
X-Route-Id: <unique identifier>
X-Route-Name: GET /path/{to}/route
```