### PR TITLE
Support for section groupings in documentation tables of contents

### DIFF
--- a/src/hunit/doc/doc.go
+++ b/src/hunit/doc/doc.go
@@ -13,7 +13,7 @@ import (
 // Implemented by documentation generators
 type Generator interface {
 	Init(*test.Suite) error
-	Case(test.Config, test.Case, *http.Request, string, *http.Response, []byte) error
+	Case(*test.Suite, test.Case, *http.Request, string, *http.Response, []byte) error
 	Finalize(*test.Suite) error
 	Close() error
 }

--- a/src/hunit/doc/emit/emit.go
+++ b/src/hunit/doc/emit/emit.go
@@ -9,7 +9,6 @@ type Doctype uint32
 
 const (
 	DoctypeMarkdown Doctype = iota
-	DoctypeConfluence
 	DoctypeInvalid
 )
 

--- a/src/hunit/doc/emit/markdown/markdown.go
+++ b/src/hunit/doc/emit/markdown/markdown.go
@@ -13,7 +13,7 @@ import (
 	"github.com/instaunit/instaunit/hunit/text/slug"
 )
 
-const defaultSection = ""
+const unassignedSection = ""
 
 type entry struct {
 	Slug, Title, Section string
@@ -110,7 +110,7 @@ func (g *Generator) contents(w io.Writer, suite *test.Suite) error {
 		groups := make(map[string][]entry)
 		rem := make([]entry, 0)
 		for _, e := range g.entries {
-			if e.Section == defaultSection {
+			if e.Section == unassignedSection {
 				rem = append(rem, e)
 			} else {
 				s, ok := groups[e.Section]

--- a/src/hunit/doc/emit/markdown/markdown.go
+++ b/src/hunit/doc/emit/markdown/markdown.go
@@ -108,10 +108,10 @@ func (g *Generator) contents(w io.Writer, suite *test.Suite) error {
 
 	if len(suite.TOC.Sections) > 0 {
 		groups := make(map[string][]entry)
-		rem := make([]entry, 0)
+		extra := make([]entry, 0)
 		for _, e := range g.entries {
 			if e.Section == unassignedSection {
-				rem = append(rem, e)
+				extra = append(extra, e)
 			} else {
 				s, ok := groups[e.Section]
 				if !ok {
@@ -130,11 +130,11 @@ func (g *Generator) contents(w io.Writer, suite *test.Suite) error {
 				doc += fmt.Sprintf("* [%s](#%s)\n", strings.TrimSpace(e.Title), e.Slug)
 			}
 		}
-		if !suite.TOC.SuppressUnassigned && len(rem) > 0 {
+		if !suite.TOC.SuppressUnassigned && len(extra) > 0 {
 			if len(suite.TOC.Sections) > 0 {
 				doc += "\n### Additional\n\n"
 			}
-			for _, e := range rem {
+			for _, e := range extra {
 				doc += fmt.Sprintf("* [%s](#%s)\n", strings.TrimSpace(e.Title), e.Slug)
 			}
 		}

--- a/src/hunit/doc/emit/markdown/markdown.go
+++ b/src/hunit/doc/emit/markdown/markdown.go
@@ -102,6 +102,10 @@ func (g *Generator) contents(w io.Writer, suite *test.Suite) error {
 
 	doc += "## Contents\n\n"
 
+	if s := suite.TOC.Comments; s != "" {
+		doc += s + "\n\n"
+	}
+
 	if len(suite.TOC.Sections) > 0 {
 		groups := make(map[string][]entry)
 		rem := make([]entry, 0)

--- a/src/hunit/test/suite.go
+++ b/src/hunit/test/suite.go
@@ -34,10 +34,23 @@ type Dependencies struct {
 	Timeout   time.Duration `yaml:"timeout"`
 }
 
+// A contents section
+type Section struct {
+	Key   string `yaml:"key"`
+	Title string `yaml:"title"`
+}
+
+// Table of contents
+type TOC struct {
+	Sections           []Section `yaml:"sections"`
+	SuppressUnassigned bool      `yaml:"suppress-unassigned"`
+}
+
 // A test suite
 type Suite struct {
 	Title    string                 `yaml:"title"`
 	Comments string                 `yaml:"doc"`
+	TOC      TOC                    `yaml:"toc"`
 	Cases    []Case                 `yaml:"tests"`
 	Config   Config                 `yaml:"options"`
 	Setup    []*exec.Command        `yaml:"setup"`

--- a/src/hunit/test/suite.go
+++ b/src/hunit/test/suite.go
@@ -43,6 +43,7 @@ type Section struct {
 // Table of contents
 type TOC struct {
 	Sections           []Section `yaml:"sections"`
+	Comments           string    `yaml:"doc"`
 	SuppressUnassigned bool      `yaml:"suppress-unassigned"`
 }
 

--- a/src/hunit/test/test.go
+++ b/src/hunit/test/test.go
@@ -90,6 +90,7 @@ type Case struct {
 	Concurrent int                    `yaml:"concurrent"`
 	Gendoc     bool                   `yaml:"gendoc"`
 	Title      string                 `yaml:"title"`
+	Section    string                 `yaml:"section"`
 	Comments   string                 `yaml:"doc"`
 	Require    bool                   `yaml:"require"`
 	Params     map[string]string      `yaml:"params"`


### PR DESCRIPTION
This adds support for grouping entries in generated documentation tables of contents into sections. This can be useful for better organizing documentation of a large set of related endpoints.

When no TOC sections are defined the behavior is as it was before: all TOC entries are displayed in a single group at the head of the document. In both cases, however, the entries are now displayed in the order they are declared in the test suite. Previously the entries were displayed in an undefined order.

To use TOC sections, first declare your sections in the test suite using the new top-level `toc` property. For example:

```yaml
title: Some Great API

toc:
  sections:
    - key: section-1
      title: The First Section
    - key: section-2
      title: The Second Section

options:
  table-of-contents: y

# ...
```

Then, map individual test cases into a section by setting the new `section` property:

```
  -
    section: section-1
    title: GET /v1/status
    doc: |
      Fetch the current status of the service.

    request:
      method: GET
      url: /v1/status

# ...
```

By default, if sections are declared, tests that have documentation but which are not assigned to a section are grouped under a single default section which is displayed at the end of the declared sections.
