### PR TITLE
Various expression stdlib updates

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/instaunit/instaunit
 
-go 1.12
+go 1.20
 
 require (
 	github.com/bww/epl v1.1.2
@@ -11,12 +11,18 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/google/go-cmp v0.5.6
 	github.com/gorilla/websocket v1.4.2
-	github.com/kr/pretty v0.3.0 // indirect
-	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f
 	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/kr/pretty v0.3.0 // indirect
+	github.com/mattn/go-colorable v0.1.11 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,12 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/aws/aws-lambda-go v1.14.0/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
-github.com/bww/epl v1.1.1 h1:7uPUqAcn+TrnIxHgW8c44wjyNk9Z6pLzXCj32Za3emM=
-github.com/bww/epl v1.1.1/go.mod h1:8CahovY2O3KqBUPSfiQzaSaNd6Bkn+SJH7L98/76vaI=
 github.com/bww/epl v1.1.2 h1:8FxPQt8c4TtDEI91QdCvkRTCVpiFxlXCWnatLQkHpfU=
 github.com/bww/epl v1.1.2/go.mod h1:8CahovY2O3KqBUPSfiQzaSaNd6Bkn+SJH7L98/76vaI=
 github.com/bww/go-alert v0.0.0-20180325011200-72270072a7e5/go.mod h1:tsrgzda5iuNbbbVRTPaUnXpHwh0qiWg//Xr7lSLV5X8=
-github.com/bww/go-router v1.6.0 h1:+Uyt4mRtW48+Dg8lorfLDSjiK91aK7J28yEzSfUjMe0=
-github.com/bww/go-router v1.6.0/go.mod h1:lP+Pg41Tkkxz29JwpgBiSocoCNQLMVxj5hevMb0B6k0=
 github.com/bww/go-router v1.7.0 h1:DFKRWmIMUHWp+iuwfx/657Bd7T6OkmWhqgPQ+PAvYFM=
 github.com/bww/go-router v1.7.0/go.mod h1:lP+Pg41Tkkxz29JwpgBiSocoCNQLMVxj5hevMb0B6k0=
 github.com/bww/go-util v1.14.1 h1:fUrW1RyObE66ZQYVf/4b7+Mp6QbAKRLMJk8IHUVBFaE=
@@ -66,7 +62,6 @@ golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -77,8 +72,6 @@ gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375/go.mod h1:lNEQeAhU009zbR
 gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/hunit/expr/runtime/base64.go
+++ b/src/hunit/expr/runtime/base64.go
@@ -6,14 +6,16 @@ import (
 )
 
 // base64 libs
-type stdBase64 struct{}
+type stdBase64 struct {
+	*base64.Encoding
+}
 
 func (s stdBase64) Encode(v interface{}) (string, error) {
 	switch c := v.(type) {
 	case []byte:
-		return base64.StdEncoding.EncodeToString(c), nil
+		return s.EncodeToString(c), nil
 	case string:
-		return base64.StdEncoding.EncodeToString([]byte(c)), nil
+		return s.EncodeToString([]byte(c)), nil
 	default:
 		return "", fmt.Errorf("Unsupported type: %T", v)
 	}
@@ -24,9 +26,9 @@ func (s stdBase64) Decode(v interface{}) (string, error) {
 	var err error
 	switch c := v.(type) {
 	case []byte:
-		d, err = base64.StdEncoding.DecodeString(string(c))
+		d, err = s.DecodeString(string(c))
 	case string:
-		d, err = base64.StdEncoding.DecodeString(c)
+		d, err = s.DecodeString(c)
 	default:
 		err = fmt.Errorf("Unsupported type: %T", v)
 	}

--- a/src/hunit/expr/runtime/stdlib.go
+++ b/src/hunit/expr/runtime/stdlib.go
@@ -1,10 +1,12 @@
 package runtime
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -19,12 +21,17 @@ func deprecated(a, b string) {
 
 // The standard library
 type stdlib struct {
-	Base64 stdBase64
-	JSON   stdJSON
+	Base64    stdBase64
+	RawBase64 stdBase64
+	JSON      stdJSON
 }
 
 // Builtins
-var Stdlib stdlib
+var Stdlib = stdlib{
+	Base64:    stdBase64{base64.StdEncoding},
+	RawBase64: stdBase64{base64.RawStdEncoding},
+	JSON:      stdJSON{},
+}
 
 // Generate a random string
 func (s stdlib) RandomString(n float64) string {
@@ -90,6 +97,24 @@ func (s stdlib) ToTitle(v string) string {
 // Trim space from both ends of a string
 func (s stdlib) TrimSpace(v string) string {
 	return strings.TrimSpace(v)
+}
+
+// Match a regular expression
+func (s stdlib) Match(expr, text string) (bool, error) {
+	r, err := regexp.Compile(expr)
+	if err != nil {
+		return false, err
+	}
+	return r.MatchString(text), nil
+}
+
+// Match and replace a regular expression
+func (s stdlib) Replace(expr, text, replace string) (string, error) {
+	r, err := regexp.Compile(expr)
+	if err != nil {
+		return "", err
+	}
+	return r.ReplaceAllString(text, replace), nil
 }
 
 // Get the current timestamp as time.Time


### PR DESCRIPTION
This adds two regular expression methods to the standard library:

* `std.Match(regex, text string) (bool, error)`
* `std.Replace(regex, text, replace string) (string, error)`

And adds a set of Base64 variants which uses the unpadded Base64 encoding, `std.RawBase64`, which provides the same functions as `std.Base64` without padding.

* `std.RawBase64.Encode(data interface{}) (string, error)`
* `std.RawBase64.Decode(data interface{}) (string, error)`
