### PR TITLE
Test case matrices

### DIFF
--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/instaunit/instaunit/hunit/doc"
 	"github.com/instaunit/instaunit/hunit/expr"
 	"github.com/instaunit/instaunit/hunit/test"
@@ -70,8 +69,6 @@ func RunSuite(suite *test.Suite, context Context) ([]*Result, error) {
 	precond := true
 	for _, f := range suite.Frames() {
 		e := f.Case // just unpack the case for now
-		spew.Dump(f)
-
 		if !precond {
 			results = append(results, &Result{Name: fmt.Sprintf("%v %v (dependency failed)\n", e.Request.Method, e.Request.URL), Skipped: true})
 			continue
@@ -110,7 +107,7 @@ func RunSuite(suite *test.Suite, context Context) ([]*Result, error) {
 				lock.Lock()
 				g := dupVars(globals)
 				lock.Unlock()
-				r, f, v, err := RunTest(suite, e, context.WithVars(g))
+				r, f, v, err := RunTest(suite, e, context.WithVars(g, f.Vars))
 				lock.Lock()
 				if v != nil && e.Id != "" {
 					globals[e.Id] = v

--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/instaunit/instaunit/hunit/doc"
 	"github.com/instaunit/instaunit/hunit/expr"
 	"github.com/instaunit/instaunit/hunit/test"
@@ -67,7 +68,10 @@ func RunSuite(suite *test.Suite, context Context) ([]*Result, error) {
 	globals := dupVars(suite.Globals)
 
 	precond := true
-	for _, e := range suite.Cases {
+	for _, f := range suite.Frames() {
+		e := f.Case // just unpack the case for now
+		spew.Dump(f)
+
 		if !precond {
 			results = append(results, &Result{Name: fmt.Sprintf("%v %v (dependency failed)\n", e.Request.Method, e.Request.URL), Skipped: true})
 			continue

--- a/src/hunit/test/suite.go
+++ b/src/hunit/test/suite.go
@@ -53,13 +53,22 @@ type Suite struct {
 	Comments string                 `yaml:"doc"`
 	TOC      TOC                    `yaml:"toc"`
 	Route    Route                  `yaml:"route"` // the route description for documentation purposes; this may be dynamic and shared by all routes in the suite
-	Cases    []Case                 `yaml:"tests"`
+	Cases    []caseOrMatrix         `yaml:"tests"`
 	Config   Config                 `yaml:"options"`
 	Setup    []*exec.Command        `yaml:"setup"`
 	Teardown []*exec.Command        `yaml:"teardown"`
 	Exec     *exec.Command          `yaml:"process"`
 	Deps     *Dependencies          `yaml:"depends"`
 	Globals  map[string]interface{} `yaml:"vars"`
+}
+
+// Produce frames for every case in the suite
+func (s Suite) Frames() []Frame {
+	var f []Frame
+	for _, e := range s.Cases {
+		f = append(f, e.Frames()...)
+	}
+	return f
 }
 
 // Load a test suite

--- a/src/hunit/test/test.go
+++ b/src/hunit/test/test.go
@@ -158,7 +158,7 @@ type caseOrMatrix struct {
 }
 
 func (c caseOrMatrix) Frames() []Frame {
-	if len(c.Matrix.Cases) > 0 {
+	if c.Matrix.Cases != nil {
 		return c.Matrix.Frames()
 	} else {
 		return c.Case.Frames()

--- a/src/hunit/test/test.go
+++ b/src/hunit/test/test.go
@@ -158,7 +158,7 @@ type caseOrMatrix struct {
 }
 
 func (c caseOrMatrix) Frames() []Frame {
-	if c.Matrix.Cases != nil {
+	if len(c.Matrix.Cases) > 0 {
 		return c.Matrix.Frames()
 	} else {
 		return c.Case.Frames()


### PR DESCRIPTION
This adds support for test case matrices. Previously, test were defined serially, like so:

```yaml
tests:
  -
    # Test case #1
  -
    # Test case #2
  -
    # ...
```

This is still the normal case. _Matrix tests_ add support for processing a set of tests repeatedly with different contexts. Each test has the same form as before, but it is executed with a set of local variables exposed to it which can be used to vary the effect of the test.

For example, we can now define a test matrix like this:

```yaml
tests:
  -
    with:
      -
        context: Context A
        base_url: /context/a
      -
        context: Context B
        base_url: /context/b
    do:
      -
        id: product
        
        doc: |
          Create a product in ${vars.context}
        
        request:
          method: POST
          url: ${vars.base}/products
          headers:
            Content-Type: application/json
          entity: |
            {
              "name": "Excellent Product"
            }

        response:
          status: 200
      
      -
        request:
          method: GET
          url: ${vars.base}/products/${product.response.value.id}

        response:
          status: 200
          compare: semantic
          entity: |
            {
              "name": "Excellent Product"
            }
```

And this is executed as if we had explicitly written each case once per variable context:

```yaml
tests:
  -
    id: product
    request:
      method: POST
      url: /contexts/a/products
      # ...
  
  -
    request:
      method: GET
      url: /contexts/a/products/${product.response.value.id}
      # ...

  -
    id: product
    request:
      method: POST
      url: /contexts/b/products
      # ...
  
  -
    request:
      method: GET
      url: /contexts/b/products/${product.response.value.id}
      # ...
```

In this example we don't save too much in an effort to be concise. However, in real world circumstances, we could easily avoid writing large numbers of test cases by parameterizing repeatitive details like prefixes or contexts.
