### PR TITLE
Improve source reporting to accommodate imports

### DIFF
--- a/src/hunit/doc/emit/openapi/openapi.go
+++ b/src/hunit/doc/emit/openapi/openapi.go
@@ -61,6 +61,9 @@ func (g *Generator) Finalize(suite *test.Suite) error {
 
 // Finalize and close the writer
 func (g *Generator) Close() error {
+	if g.w == nil {
+		return nil // nothing to do
+	}
 	defer func() {
 		g.w.Close()
 		g.w = nil
@@ -139,7 +142,7 @@ func (g *Generator) Close() error {
 			ctype := text.Coalesce(firstValue(req.Req.Header["Content-Type"]), "text/plain")
 			reqcnt = Payload{
 				Content: map[string]Schema{
-					ctype: Schema{
+					ctype: {
 						Example: newValue(ctype, []byte(req.Data)),
 					},
 				},

--- a/src/hunit/expr/expr.go
+++ b/src/hunit/expr/expr.go
@@ -68,7 +68,7 @@ func InterpolateAll(a, v Variables) (Variables, error) {
 func interpolate(s, pre, suf string, context interface{}) (string, error) {
 	defer func() {
 		if err := recover(); err != nil {
-			panic(fmt.Errorf("%w: [%s] with context: %s)", err, s, spew.Sdump(context)))
+			panic(fmt.Errorf("%v: [%s] with context: %s)", err, s, spew.Sdump(context)))
 		}
 	}()
 

--- a/src/hunit/expr/runtime/stdlib.go
+++ b/src/hunit/expr/runtime/stdlib.go
@@ -40,6 +40,11 @@ func (s stdlib) RandomString(n float64) string {
 	return rand.RandomString(int(n))
 }
 
+// Generate a random string composed of digits
+func (s stdlib) RandomDigits(n float64) string {
+	return rand.RandomStringFromSet(int(n), rand.Digit)
+}
+
 // Generate a random name (Docker style: <adjective>_<noun>)
 func (s stdlib) RandomIdent() string {
 	l, r := DockerName()

--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -30,6 +30,12 @@ func RunSuite(suite *test.Suite, context runtime.Context) ([]*Result, error) {
 	results := make([]*Result, 0)
 	globals := dupVars(suite.Globals)
 
+	// this is weird, but yes, we're evaulating globals in terms of themselves
+	globals, err := expr.InterpolateAll(globals, globals)
+	if err != nil {
+		return nil, fmt.Errorf("Could not evaluate global: %w", err)
+	}
+
 	precond := true
 	for _, f := range suite.Frames() {
 		e := f.Case // just unpack the case for now

--- a/src/hunit/hunit.go
+++ b/src/hunit/hunit.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -490,7 +491,7 @@ func formatName(c test.Case, method, url string) string {
 	if v := c.Response.Status; v != 0 {
 		sb.WriteString(fmt.Sprintf(" (expect: %d/%s)", v, http.StatusText(v)))
 	}
-	sb.WriteString(fmt.Sprintf(" @ line %d", c.Source.Line))
+	sb.WriteString(fmt.Sprintf(" @ %s:%d", path.Base(c.Source.File), c.Source.Line))
 	sb.WriteString("\n")
 	return sb.String()
 }

--- a/src/hunit/test/test.go
+++ b/src/hunit/test/test.go
@@ -80,6 +80,7 @@ type Comments struct {
 
 // Source annotation
 type Source struct {
+	File         string
 	Line, Column int
 	Comments     Comments
 }
@@ -112,7 +113,7 @@ func (m *Matrix) Annotate(node *yaml.Node, src Source) error {
 	for i, e := range node.Content {
 		if e.Kind == yaml.ScalarNode && e.Value == "do" {
 			if i+1 < l && node.Content[i+1].Kind == yaml.SequenceNode {
-				return annotate(m.Cases, node.Content[i+1]) // once we find it, nothing else to do
+				return annotate(m.Cases, src.File, node.Content[i+1]) // once we find it, nothing else to do
 			}
 		}
 	}

--- a/src/hunit/url_test.go
+++ b/src/hunit/url_test.go
@@ -2,11 +2,13 @@ package hunit
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/instaunit/instaunit/hunit/runtime"
+	"github.com/stretchr/testify/assert"
 )
 
-var urlContext = Context{}
+var urlContext = runtime.Context{}
 
 // Test URL resemblance
 func TestAbsoluteURL(t *testing.T) {

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -314,22 +314,22 @@ suites:
 		}
 
 		var (
-			suite *test.Suite
-			base  string
-			root  string
-			err   error
+			suite      *test.Suite
+			base       string
+			file, root string
+			err        error
 		)
 		cdup := config // copy global configs and update them
 
 		var reader io.Reader
 		if e == stdinPath {
 			base = "(stdin)"
-			root = "."
+			file, root = "<stdin>", "."
 			color.New(colorSuite...).Printf("====> %s", base)
 			reader = os.Stdin
 		} else {
 			base = path.Base(e)
-			root = path.Dir(e)
+			file, root = e, path.Dir(e)
 			color.New(colorSuite...).Printf("====> %s", base)
 			f, err := os.Open(e)
 			if err != nil {
@@ -341,7 +341,7 @@ suites:
 			reader = f
 		}
 
-		suite, err = test.LoadSuiteFromReader(&cdup, root, reader)
+		suite, err = test.LoadSuiteFromReader(&cdup, file, root, reader)
 		if err != nil {
 			color.New(colorErr...).Println("\n* * * Could not load test suite:", err)
 			errno++


### PR DESCRIPTION
Source reporting now includes the source file in addition to the line number to accommodate the fact that source from more than one file may be referenced.

Also:
* Adding new `std.RandomDigits(n int)` function to generate a random string with the format: `[0-9]{n}`
* Minor cleanup in OpenAPI finalization